### PR TITLE
use bosh_job_index instead of bosh_index

### DIFF
--- a/src/cloudfoundry_dashboards/cf_router.json
+++ b/src/cloudfoundry_dashboards/cf_router.json
@@ -280,9 +280,9 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "firehose_value_metric_gorouter_latency{bosh_deployment=~\"$bosh_deployment\"}",
+              "expr": "firehose_value_metric_gorouter_latency{bosh_deployment=~\"$bosh_deployment\"} * on (bosh_job_id) group_left(bosh_job_index) bosh_job_healthy",
               "intervalFactor": 2,
-              "legendFormat": "{{bosh_deployment}}/{{bosh_job}}/{{bosh_index}}",
+              "legendFormat": "{{bosh_deployment}}/{{bosh_job}}/{{bosh_job_index}}",
               "refId": "A",
               "step": 10
             }
@@ -358,9 +358,9 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "firehose_value_metric_gorouter_route_lookup_time{bosh_deployment=~\"$bosh_deployment\"}",
+              "expr": "firehose_value_metric_gorouter_route_lookup_time{bosh_deployment=~\"$bosh_deployment\"} * on (bosh_job_id) group_left(bosh_job_index) bosh_job_healthy",
               "intervalFactor": 2,
-              "legendFormat": "{{bosh_deployment}}/{{bosh_job}}/{{bosh_index}}",
+              "legendFormat": "{{bosh_deployment}}/{{bosh_job}}/{{bosh_job_index}}",
               "refId": "A",
               "step": 10
             }


### PR DESCRIPTION
Takes advantage of https://github.com/cloudfoundry-community/firehose_exporter/pull/9 to display router jobs nicely (as /0, /1, etc). Unfortunately this removes history from the graphs because old entries do not match.