### PR TITLE
and org_id and space_id to the queries

### DIFF
--- a/src/cloudfoundry_dashboards/cf_apps_metrics.json
+++ b/src/cloudfoundry_dashboards/cf_apps_metrics.json
@@ -185,7 +185,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(firehose_container_metric_cpu_percentage) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\"}",
+              "expr": "avg(firehose_container_metric_cpu_percentage) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\",space_name=~\"$cf_space_name\",organization_name=~\"$cf_organization_name\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "Used",
@@ -276,7 +276,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(firehose_container_metric_memory_bytes) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\"}",
+              "expr": "avg(firehose_container_metric_memory_bytes) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\",space_name=~\"$cf_space_name\",organization_name=~\"$cf_organization_name\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "Used",
@@ -284,7 +284,7 @@
               "step": 4
             },
             {
-              "expr": "avg(firehose_container_metric_memory_bytes_quota) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\"}",
+              "expr": "avg(firehose_container_metric_memory_bytes_quota) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\",space_name=~\"$cf_space_name\",organization_name=~\"$cf_organization_name\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "Quota",
@@ -375,7 +375,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(firehose_container_metric_disk_bytes) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\"}",
+              "expr": "avg(firehose_container_metric_disk_bytes) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\",space_name=~\"$cf_space_name\",organization_name=~\"$cf_organization_name\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "Used",
@@ -383,7 +383,7 @@
               "step": 4
             },
             {
-              "expr": "avg(firehose_container_metric_disk_bytes_quota) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\"}",
+              "expr": "avg(firehose_container_metric_disk_bytes_quota) by(application_id) * on(application_id) group_left(application_name, organization_name, space_name) cf_application_info{application_name=~\"$cf_application_name\",space_name=~\"$cf_space_name\",organization_name=~\"$cf_organization_name\"}",
               "intervalFactor": 2,
               "legendFormat": "Quota",
               "refId": "B",


### PR DESCRIPTION
Currently if you have an app with the same name in different orgs or spaces you'll get information about all of them. This patch fixes that.