### PR TITLE
make server_name configurable

### DIFF
--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -66,6 +66,9 @@ properties:
     description: "Timeout for send queries to the upstream server"
     default: 120
 
+  nginx.alertmanager.server_name:
+    description: "Server name that proxy will listen on for Alertmanager HTTP(S) connections"
+    default: _
   nginx.alertmanager.http_port:
     description: "Port that proxy will listen on for Alertmanager HTTP connections"
     default: 9093
@@ -80,6 +83,9 @@ properties:
   nginx.alertmanager.auth_password:
     description: "Alertmanager auth password"
 
+  nginx.grafana.server_name:
+    description: "Server name that proxy will listen on for Grafana HTTP(S) connections"
+    default: _
   nginx.grafana.http_port:
     description: "Port that proxy will listen on for Grafana HTTP connections"
     default: 3000
@@ -94,6 +100,9 @@ properties:
   nginx.grafana.auth_password:
     description: "Grafana auth password"
 
+  nginx.prometheus.server_name:
+    description: "Server name that proxy will listen on for Prometheus HTTP(S) connections"
+    default: _
   nginx.prometheus.http_port:
     description: "Port that proxy will listen on for Prometheus HTTP connections"
     default: 9090

--- a/jobs/nginx/templates/config/nginx.conf
+++ b/jobs/nginx/templates/config/nginx.conf
@@ -58,7 +58,7 @@ http {
 
   server {
     listen                  <%= p('nginx.alertmanager.http_port') %>;
-    server_name             _;
+    server_name             <%= p('nginx.alertmanager.server_name') %>;
     server_name_in_redirect off;
 
     ssl off;
@@ -73,7 +73,7 @@ http {
   <% if_p('nginx.ssl_cert', 'nginx.ssl_key') do %>
   server {
     listen                  <%= p('nginx.alertmanager.https_port') %>;
-    server_name             _;
+    server_name             <%= p('nginx.alertmanager.server_name') %>;
     server_name_in_redirect off;
 
     ssl                       on;
@@ -100,7 +100,7 @@ http {
 
   server {
     listen                  <%= p('nginx.grafana.http_port') %>;
-    server_name             _;
+    server_name             <%= p('nginx.grafana.server_name') %>;
     server_name_in_redirect off;
 
     ssl off;
@@ -115,7 +115,7 @@ http {
   <% if_p('nginx.ssl_cert', 'nginx.ssl_key') do %>
   server {
     listen                  <%= p('nginx.grafana.https_port') %>;
-    server_name             _;
+    server_name             <%= p('nginx.grafana.server_name') %>;
     server_name_in_redirect off;
 
     ssl                       on;
@@ -142,7 +142,7 @@ http {
 
   server {
     listen                  <%= p('nginx.prometheus.http_port') %>;
-    server_name             _;
+    server_name             <%= p('nginx.prometheus.server_name') %>;
     server_name_in_redirect off;
 
     ssl off;
@@ -157,7 +157,7 @@ http {
   <% if_p('nginx.ssl_cert', 'nginx.ssl_key') do %>
   server {
     listen                  <%= p('nginx.prometheus.https_port') %>;
-    server_name             _;
+    server_name             <%= p('nginx.prometheus.server_name') %>;
     server_name_in_redirect off;
 
     ssl                       on;


### PR DESCRIPTION
In some environments access to ports such as 3000 and 9090 is restricted. Therefore it is useful for nginx to listen on the standard ports (80/443) and to use the server_name to differentiate between grafana, prometheus and alertmanager. The defaults remain the same.