### PR TITLE
Allow setting of HTTP and HTTPS proxy vars

### DIFF
--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -39,6 +39,10 @@ properties:
     description: "Port to listen on for the web interface and API"
     default: "9093"
 
+
+  alertmanager.http_proxy:
+    description: "Will set HTTP_PROXY and HTTPS_PROXY for alertmanager"
+
   alertmanager.resolve_timeout:
     description: "ResolveTimeout is the time after which an alert is declared resolved if it has not been updated"
 

--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -41,7 +41,11 @@ properties:
 
 
   alertmanager.http_proxy:
-    description: "Will set HTTP_PROXY and HTTPS_PROXY for alertmanager"
+    description: "Will set HTTP_PROXY for alertmanager"
+  alertmanager.https_proxy:
+    description: "Will set HTTPS_PROXY for alertmanager"
+  alertmanager.no_proxy:
+    description: "Will set NO_PROXY for alertmanager"
 
   alertmanager.resolve_timeout:
     description: "ResolveTimeout is the time after which an alert is declared resolved if it has not been updated"

--- a/jobs/alertmanager/templates/bin/alertmanager_ctl
+++ b/jobs/alertmanager/templates/bin/alertmanager_ctl
@@ -19,7 +19,11 @@ case $1 in
     pid_guard ${PIDFILE} "alertmanager"
     echo $$ > ${PIDFILE}
 
-    exec alertmanager \
+    exec \
+    <% if_p('alertmanager.http_proxy') do |http_proxy| %> \
+       env HTTP_PROXY="<%= http_proxy %>" env HTTPS_PROXY="<%= http_proxy %>" \
+    <% end %> \
+    alertmanager \
       -config.file="/var/vcap/jobs/alertmanager/config/alertmanager.yml" \
       <% if_p('alertmanager.data.retention') do |retention| %> \
       -data.retention="<%= retention %>" \

--- a/jobs/alertmanager/templates/bin/alertmanager_ctl
+++ b/jobs/alertmanager/templates/bin/alertmanager_ctl
@@ -21,7 +21,13 @@ case $1 in
 
     exec \
     <% if_p('alertmanager.http_proxy') do |http_proxy| %> \
-       env HTTP_PROXY="<%= http_proxy %>" env HTTPS_PROXY="<%= http_proxy %>" \
+       env HTTP_PROXY="<%= http_proxy %>" env http_proxy="<%= http_proxy %>" \
+    <% end %> \
+    <% if_p('alertmanager.https_proxy') do |https_proxy| %> \
+       env HTTPS_PROXY="<%= https_proxy %>" env https_proxy="<%= https_proxy %>"\
+    <% end %> \
+    <% if_p('alertmanager.no_proxy') do |no_proxy| %> \
+       env NO_PROXY="<%= no_proxy %>" env no_proxy="<%= no_proxy %>" \
     <% end %> \
     alertmanager \
       -config.file="/var/vcap/jobs/alertmanager/config/alertmanager.yml" \


### PR DESCRIPTION
When sitting behind a `proxy` the `alertmanager` is not able to ping `slack` or whatever outside service. This PR allows to set a `http_proxy` setting which will configure `http_proxy` and `https_proxy` for the `alertmanager`.