### PR TITLE
Add remote_write property to prometheus job

### DIFF
--- a/jobs/prometheus/spec
+++ b/jobs/prometheus/spec
@@ -37,6 +37,8 @@ properties:
     description: "Array of paths to Prometheus rule files"
   prometheus.scrape_configs:
     description: "Array of scrape configurations"
+  prometheus.remote_write:
+    description: "Remote storage configuration"
 
   prometheus.alertmanager.notification_queue_capacity:
     description: "The capacity of the queue for pending alert manager notifications"

--- a/jobs/prometheus/templates/config/prometheus.yml
+++ b/jobs/prometheus/templates/config/prometheus.yml
@@ -23,3 +23,8 @@ rule_files: <%= p('prometheus.rule_files', []).to_json %>
 
 # A list of scrape configurations.
 scrape_configs: <%= p('prometheus.scrape_configs', []).to_json %>
+
+<% if_p('prometheus.remote_write') do |remote_write| %>
+# Write samples to remote storage.
+remote_write: <%= remote_write.to_json %>
+<% end %>


### PR DESCRIPTION
This allows operators to configure [remote storage](https://prometheus.io/docs/operating/configuration/#<remote_write>). If set, samples will
be sent to a remote endpoint.