### PR TITLE
Include path in proxy_pass directive.

### DIFF
--- a/jobs/nginx/templates/config/alertmanager_location.conf
+++ b/jobs/nginx/templates/config/alertmanager_location.conf
@@ -1,5 +1,5 @@
 location <%= p('nginx.alertmanager.path') %> {
-    proxy_pass            http://alertmanager;
+    proxy_pass            http://alertmanager/;
     <% if p('nginx.ssl_only') %>
     proxy_redirect        http:// https://;
     <% end %>

--- a/jobs/nginx/templates/config/grafana_location.conf
+++ b/jobs/nginx/templates/config/grafana_location.conf
@@ -1,5 +1,5 @@
 location <%= p('nginx.grafana.path') %> {
-    proxy_pass            http://grafana;
+    proxy_pass            http://grafana/;
     <% if p('nginx.ssl_only') %>
     proxy_redirect        http:// https://;
     <% end %>

--- a/jobs/nginx/templates/config/prometheus_location.conf
+++ b/jobs/nginx/templates/config/prometheus_location.conf
@@ -1,5 +1,5 @@
 location <%= p('nginx.prometheus.path') %> {
-    proxy_pass            http://prometheus;
+    proxy_pass            http://prometheus/;
     <% if p('nginx.ssl_only') %>
     proxy_redirect        http:// https://;
     <% end %>


### PR DESCRIPTION
This strips the path from the url before forwarding to the upstream. From the nginx docs:

> If proxy_pass is specified without a URI, the request URI is passed to the server in the same form as sent by a client when the original request is processed, or the full normalized request URI is passed when processing the changed URI