### PR TITLE
Require operators to set non-default admin password.

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -96,7 +96,6 @@ properties:
     default: admin
   grafana.security.admin_password:
     description: "default admin password"
-    default: admin
   grafana.security.secret_key:
     description: "used for signing"
   grafana.security.login_remember_days:

--- a/jobs/grafana/templates/config/grafana.ini
+++ b/jobs/grafana/templates/config/grafana.ini
@@ -149,15 +149,11 @@ google_analytics_ua_id = <%= google_analytics_ua_id %>
 
 #################################### Security ####################################
 [security]
-<% if_p('grafana.security.admin_user') do |admin_user| %>
 # default admin user, created on startup
-admin_user = <%= admin_user %>
-<% end %>
+admin_user = <%= p('grafana.security.admin_user') %>
 
-<% if_p('grafana.security.admin_password') do |admin_password| %>
-# default admin password, can be changed before first start of grafana,  or in profile settings
-admin_password = <%= admin_password %>
-<% end %>
+# default admin password, can be changed before first start of grafana, or in profile settings
+admin_password = <%= p('grafana.security.admin_password') %>
 
 <% if_p('grafana.security.secret_key') do |secret_key| %>
 # used for signing


### PR DESCRIPTION
So that users don't accidentally use the default of admin / admin.