### PR TITLE
Accept glob patterns in grafana dashboard files.

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -362,4 +362,4 @@ properties:
     description: "Name of the Prometehus datasource input name"
     default: DS_PROMETHEUS
   grafana.prometheus.dashboard_files:
-    description: "Array of dashboard json file locations"
+    description: "Array of dashboard json file locations or glob patterns"

--- a/jobs/grafana/templates/bin/prometheus-dashboards
+++ b/jobs/grafana/templates/bin/prometheus-dashboards
@@ -8,10 +8,11 @@ rm -fr ${DASHBOARDS_DIR}/*
 
 <% if_link('prometheus') do |prometheus| %>
 <% p('grafana.prometheus.dashboard_files', []).each do |dashboard_file| %>
-dashboard_file="<%= dashboard_file %>"
-filename=$(basename "${dashboard_file}")
-echo -e "Updating dashboard ${dashboard_file} at $(date)"
-sed 's/\${<%= p('grafana.prometheus.datasource_input_name') %>}/<%= p('grafana.prometheus.datasource_name') %>/g' "${dashboard_file}" > "${DASHBOARDS_DIR}/${filename}"
+for dashboard_file in $(ls "<%= dashboard_file %>"); do
+  filename=$(basename "${dashboard_file}")
+  echo -e "Updating dashboard ${dashboard_file} at $(date)"
+  sed 's/\${<%= p('grafana.prometheus.datasource_input_name') %>}/<%= p('grafana.prometheus.datasource_name') %>/g' "${dashboard_file}" > "${DASHBOARDS_DIR}/${filename}"
+done
 <% end %>
 <% end %>
 


### PR DESCRIPTION
So that we can use something like

```yaml
properties:
  grafana:
    prometheus:
      dashboard_files:
      - /var/vcap/packages/bosh_dashboards/*.json
```

instead of listing all dashboard files manually.