### PR TITLE
fix the prometheus-dashboards script

### DIFF
--- a/jobs/grafana/templates/bin/prometheus-dashboards
+++ b/jobs/grafana/templates/bin/prometheus-dashboards
@@ -8,7 +8,7 @@ rm -fr ${DASHBOARDS_DIR}/*
 
 <% if_link('prometheus') do |prometheus| %>
 <% p('grafana.prometheus.dashboard_files', []).each do |dashboard_file| %>
-for dashboard_file in $(ls "<%= dashboard_file %>"); do
+for dashboard_file in $(ls <%= dashboard_file %>); do
   filename=$(basename "${dashboard_file}")
   echo -e "Updating dashboard ${dashboard_file} at $(date)"
   sed 's/\${<%= p('grafana.prometheus.datasource_input_name') %>}/<%= p('grafana.prometheus.datasource_name') %>/g' "${dashboard_file}" > "${DASHBOARDS_DIR}/${filename}"

--- a/src/cloudfoundry_dashboards/cf_organization_memory_quotas.json
+++ b/src/cloudfoundry_dashboards/cf_organization_memory_quotas.json
@@ -99,7 +99,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "((sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name, application_id)) by(organization_name) / on(organization_name) avg(cf_organization_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name) > 0 )* 100 > $quota_limit) * on (organization_name) group_left(quota_name) cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}",
+              "expr": "((sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name, application_id)* on (organization_name, application_id) cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",state=\"STARTED\"}) by(organization_name) / on(organization_name) avg(cf_organization_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name) > 0 )* 100 > $quota_limit) * on (organization_name) group_left(quota_name) cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "{{ organization_name }} ({{ quota_name }})",
@@ -188,7 +188,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name) * on (organization_name) group_left(quota_name) cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}",
+              "expr": "sum(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"} * on (organization_name, application_id) cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",state=\"STARTED\"}) by(organization_name) * on (organization_name) group_left(quota_name) cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "{{ organization_name }} ({{ quota_name }})",
@@ -399,5 +399,5 @@
   },
   "timezone": "browser",
   "title": "CF: Organization Memory Quotas",
-  "version": 1
+  "version": 6
 }


### PR DESCRIPTION
A bug was introduced with the glob patterns support that caused this script not to process any dashboards with errors like this:
ls: cannot access /var/vcap/packages/cloudfoundry_dashboards/*.json: No such file or directory

It works for me after removing quotes.