### PR TITLE
Fix: Alertmanager set mesh.peer from the spec file

### DIFF
--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -34,7 +34,7 @@ properties:
   alertmanager.mesh.password:
     description: "password to join the peer network (empty password disables encryption)"
   alertmanager.mesh.peer:
-    description: "initial peers"
+    description: "initial peers as a list"
   alertmanager.web.external_url:
     description: "The URL under which Alertmanager is externally reachable"
   alertmanager.web.port:

--- a/jobs/alertmanager/templates/bin/alertmanager_ctl
+++ b/jobs/alertmanager/templates/bin/alertmanager_ctl
@@ -50,6 +50,9 @@ case $1 in
       <% link('alertmanager').instances.each do |instance|  %> \
       -mesh.peer="<%= "#{instance.address}:#{link('alertmanager').p('alertmanager.mesh.port')}" %>" \
       <% end %> \
+      <% if_p('alertmanager.mesh.peer') do |peer|  %> \
+      -mesh.peer="<%= peer %>" \
+      <% end %> \
       -storage.path="${STORE_DIR}" \
       <% if_p('alertmanager.web.external_url') do |external_url| %> \
       -web.external-url="<%= external_url %>" \


### PR DESCRIPTION
In the spec for the alertmanager user could set `alertmanager.mesh.peer` but it wasn't use in the template `alertmanager_ctl`

You can see here inside the spec: https://github.com/cloudfoundry-community/prometheus-boshrelease/blob/master/jobs/alertmanager/spec#L36-L37
 and what is set in the template file: https://github.com/cloudfoundry-community/prometheus-boshrelease/blob/master/jobs/alertmanager/templates/bin/alertmanager_ctl#L50-L52

Now, alertmanager_ctl will run properly when user set `alertmanager.mesh.peer` in his manifest.