### PR TITLE
Add bosh_job_name filter to cf_cells_capacity

### DIFF
--- a/src/cloudfoundry_dashboards/cf_cells_capacity.json
+++ b/src/cloudfoundry_dashboards/cf_cells_capacity.json
@@ -131,7 +131,7 @@
           },
           "targets": [
             {
-              "expr": "count(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+              "expr": "count(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"})",
               "intervalFactor": 2,
               "metric": "firehose_value_metric_rep_capacity_total_containers",
               "refId": "A",
@@ -208,7 +208,7 @@
           },
           "targets": [
             {
-              "expr": "bottomk(1, firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+              "expr": "bottomk(1, firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"})",
               "intervalFactor": 2,
               "metric": "firehose_value_metric_rep_capacity_remaining_memory",
               "refId": "A",
@@ -287,7 +287,7 @@
           },
           "targets": [
             {
-              "expr": "bottomk(1, firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+              "expr": "bottomk(1, firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"})",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "{{ bosh_job_ip }}",
@@ -359,7 +359,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(avg(firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_id)) - sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_id))",
+              "expr": "sum(avg(firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_id, bosh_job_name)) - sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_id, bosh_job_name))",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "Used",
@@ -367,7 +367,7 @@
               "step": 60
             },
             {
-              "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_id))",
+              "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_id))",
               "intervalFactor": 2,
               "legendFormat": "Available",
               "refId": "B",
@@ -458,14 +458,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(avg(firehose_value_metric_rep_capacity_total_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_id)) - sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_id))",
+              "expr": "sum(avg(firehose_value_metric_rep_capacity_total_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_id)) - sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_id))",
               "intervalFactor": 2,
               "legendFormat": "Used",
               "refId": "A",
               "step": 60
             },
             {
-              "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_id))",
+              "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_id))",
               "intervalFactor": 2,
               "legendFormat": "Available",
               "refId": "B",
@@ -548,7 +548,7 @@
           "strokeWidth": 1,
           "targets": [
             {
-              "expr": "firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"} - firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}",
+              "expr": "firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"} - firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "{{ bosh_job_ip }}",
@@ -587,7 +587,7 @@
           "strokeWidth": 1,
           "targets": [
             {
-              "expr": "firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"} - firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}",
+              "expr": "firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"} - firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "{{ bosh_job_ip }}",
@@ -648,6 +648,26 @@
         "name": "bosh_deployment",
         "options": [],
         "query": "label_values(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\"}, bosh_deployment)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": null,
+        "tags": [],
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Bosh_job_name",
+        "multi": true,
+        "name": "bosh_job_name",
+        "options": [],
+        "query": "label_values(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}, bosh_job_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/src/cloudfoundry_dashboards/cf_cells_capacity.json
+++ b/src/cloudfoundry_dashboards/cf_cells_capacity.json
@@ -663,7 +663,7 @@
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
         "includeAll": true,
-        "label": "Bosh_job_name",
+        "label": "Job",
         "multi": true,
         "name": "bosh_job_name",
         "options": [],


### PR DESCRIPTION
I added `bosh_job_name` filter to cf_cells_capacity dashboard
In production environments, each cell has different computing resources or need to calculate resources for specific cell groups
For example case, when deployed colocated cell per projects or limited resource environment
It will be useful to calculate capacity for each cell or groups of cells

![cells](https://cloud.githubusercontent.com/assets/4901749/25115242/da11d358-243f-11e7-8bb5-39097d33c5ff.PNG)
