### PR TITLE
Add `grafana.dashboards.custom_homepage_json` bosh property

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -343,6 +343,8 @@ properties:
 
   grafana.dashboards.json.enabled:
     description: "Enable Dashboard JSON files"
+  grafana.dashboards.custom_homepage_json:
+    description: "Override the default homepage with a custom dashboard in JSON format (http://docs.grafana.org/reference/dashboard/)"
 
   grafana.quota.enabled:
     description: "Enable Usage Quotas"

--- a/jobs/grafana/templates/bin/prometheus-dashboards
+++ b/jobs/grafana/templates/bin/prometheus-dashboards
@@ -4,6 +4,7 @@ set -eu
 shopt -s nullglob
 
 DASHBOARDS_DIR=/var/vcap/store/grafana/dashboards/
+JQ_CMD=/var/vcap/packages/grafana_jq/bin/jq
 rm -fr ${DASHBOARDS_DIR}/*
 
 <% if_link('prometheus') do |prometheus| %>
@@ -15,9 +16,24 @@ for dashboard_file in $(ls <%= dashboard_file %>); do
   sed 's/\${<%= p('grafana.prometheus.datasource_input_name') %>}/<%= p('grafana.prometheus.datasource_name') %>/g' "${dashboard_file}" > "${DASHBOARDS_DIR}/${filename}"
   echo -e "Validating ${DASHBOARDS_DIR}/${filename}"
   # want stderr going to stdout, don't want stdout at all
-  /var/vcap/packages/grafana_jq/bin/jq . < ${DASHBOARDS_DIR}/${filename} 2>&1 > /dev/null
+  ${JQ_CMD} . < ${DASHBOARDS_DIR}/${filename} 2>&1 > /dev/null
 done
 <% end %>
+<% end %>
+
+<% if_p('grafana.dashboards.custom_homepage_json') do |homepage_json| %>
+GRAFANA_API="<%= p('grafana.server.protocol', 'http') %>://<%= spec.address %>:<%= p('grafana.server.http_port') %>"
+GRAFANA_CREDENTIALS="<%= p('grafana.security.admin_user') %>:<%= p('grafana.security.admin_password') %>"
+upsert_dash_resp="$(curl -u ${GRAFANA_CREDENTIALS} -ksf -X POST "${GRAFANA_API}/api/dashboards/db" \
+  -H 'Content-Type: application/json' \
+  -d '{ "dashboard": <%= homepage_json %>, "overwrite": true }')"
+dash_slug="$( ${JQ_CMD} -r .slug <<< "${upsert_dash_resp}" )"
+get_dash_resp="$(curl -u ${GRAFANA_CREDENTIALS} -ksf -X GET "${GRAFANA_API}/api/dashboards/db/${dash_slug}" \
+  -H 'Content-Type: application/json')"
+dash_id="$( ${JQ_CMD} -r .dashboard.id <<< "${get_dash_resp}" )"
+curl -u ${GRAFANA_CREDENTIALS} -ksf -X PUT "${GRAFANA_API}/api/org/preferences" \
+  -H 'Content-Type: application/json' \
+  -d "{ \"homeDashboardId\": ${dash_id} }"
 <% end %>
 <% end %>
 


### PR DESCRIPTION
- Allows operator to specify a custom homepage for the default org in
  the deployment manifest
- The manifest property should be a JSON string in the following format:
  http://docs.grafana.org/reference/dashboard/