### PR TITLE
Optionally alert on outdated stemcells.

### DIFF
--- a/jobs/bosh_alerts/spec
+++ b/jobs/bosh_alerts/spec
@@ -15,6 +15,11 @@ templates:
   prometheus_bosh_tsdb_exporter.alerts: prometheus_bosh_tsdb_exporter.alerts
 
 properties:
+  bosh_alerts.deployment_stemcell_outdated.version:
+    description: "Deployment stemcell outdated current version"
+  bosh_alerts.deployment_stemcell_outdated.evaluation_time:
+    description: "Deployment stemcell outdated alert evaluation time"
+    default: 1h
   bosh_alerts.job_unhealthy.evaluation_time:
     description: "Job unhealthy alert evaluation time"
     default: 5m

--- a/jobs/bosh_alerts/templates/bosh_deployments.alerts
+++ b/jobs/bosh_alerts/templates/bosh_deployments.alerts
@@ -1,0 +1,13 @@
+<% if_p("bosh_alerts.deployment_stemcell_outdated.version") do |version| %>
+ALERT BOSHDeploymentStemcells
+  IF count(bosh_deployment_stemcell_info{bosh_stemcell_version!="<%= version %>"}) by (environment, bosh_name, bosh_deployment) != 0
+  FOR <%= p("bosh_alerts.deployment_stemcell_outdated.evaluation_time") %>
+  LABELS {
+    service = "bosh-deployment",
+    severity = "critical",
+  }
+  ANNOTATIONS {
+    summary = "BOSH Deployment `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}` has been using an outdated stemcell for a long time",
+    description = "BOSH Deployment `{{$labels.environment}}/{{$labels.bosh_name}}/{{$labels.bosh_deployment}}` has been using using an outdated stemcell for <%= p("bosh_alerts.deployment_stemcell_outdated.evaluation_time") %>",
+  }
+<% end %>


### PR DESCRIPTION
For compliance and security purposes, we want to be alerted when deployments are using an outdated stemcell. We're planning to update this property via concourse using a `bosh-io-stemcell` resource.

cc @cnelson