### PR TITLE
Add elasticsearch alerts.

### DIFF
--- a/jobs/elasticsearch_alerts/spec
+++ b/jobs/elasticsearch_alerts/spec
@@ -1,0 +1,17 @@
+---
+name: elasticsearch_alerts
+
+packages: []
+
+templates:
+  cluster.alerts: cluster.alerts
+
+properties:
+  elasticsearch_alerts.cluster_down.evaluation_time:
+    description: "Elasticsearch down alert evaluation time"
+    default: 5m
+  elasticsearch_alerts.cluster_red.evaluation_time:
+    description: "Elasticsearch cluster health red evaluation time"
+    default: 5m
+  elasticsearch_alerts.cluster_yellow.evaluation_time:
+    description: "Elasticsearch cluster health yellow evaluation time"

--- a/jobs/elasticsearch_alerts/templates/cluster.alerts
+++ b/jobs/elasticsearch_alerts/templates/cluster.alerts
@@ -1,0 +1,37 @@
+ALERT ElasticUp
+  IF elasticsearch_up != 1
+  FOR <%= p('elasticsearch_alerts.cluster_down.evaluation_time') %>
+  LABELS {
+    service = "elasticsearch",
+    severity = "critical",
+  }
+  ANNOTATIONS {
+    summary = "Elasticsearch instance {{$labels.instance}} is not responding",
+    description = "Elasticsearch instance {{$labels.instance}} is not responding",
+  }
+
+ALERT ElasticClusterRed
+  IF elasticsearch_cluster_health_status = 2
+  FOR <%= p('elasticsearch_alerts.cluster_red.evaluation_time') %>
+  LABELS {
+    service = "elasticsearch",
+    severity = "critical",
+  }
+  ANNOTATIONS {
+    summary = "Cluster {{$labels.cluster}} is red",
+    description = "Cluster {{$labels.cluster}} is red",
+  }
+
+<% if_p('elasticsearch_alerts.cluster_yellow.evaluation_time') do |time| %>
+ALERT ElasticClusterYellow
+  IF elasticsearch_cluster_health_status = 1
+  FOR <%= time %>
+  LABELS {
+    service = "elasticsearch",
+    severity = "warning",
+  }
+  ANNOTATIONS {
+    summary = "Cluster {{$labels.cluster}} is yellow",
+    description = "Cluster {{$labels.cluster}} is yellow",
+  }
+<% end %>


### PR DESCRIPTION
Adapted from https://grafana.com/dashboards/2322. Note: the elastic exporter emits green as 0, yellow as 1, and red as 2: https://github.com/justwatchcom/elasticsearch_exporter/blob/master/exporter.go#L568-L578.

I made the alert on yellow optional, since elastic clusters might be yellow for a long time during a rolling restart.

cc @cnelson @LinuxBozo