### PR TITLE
Add minimal concourse alerts.

### DIFF
--- a/jobs/concourse_alerts/spec
+++ b/jobs/concourse_alerts/spec
@@ -1,0 +1,15 @@
+---
+name: concourse_alerts
+
+packages: []
+
+templates:
+  concourse.alerts: concourse.alerts
+
+properties:
+  concourse_alerts.worker_containers.evaluation_time:
+    description: "Worker containers evaluation time"
+    default: 5m
+  concourse_alerts.worker_containers.threshold:
+    description: "Worker containers alert threshold"
+    default: 200  # Four-fifths of the default container limit in garden-runc

--- a/jobs/concourse_alerts/templates/concourse.alerts
+++ b/jobs/concourse_alerts/templates/concourse.alerts
@@ -1,0 +1,11 @@
+ALERT ConcourseHighWorkerContainers
+  IF worker_containers by(bosh_deployment, worker) > <%= p('concourse_alerts.worker_containers.threshold') %>
+  FOR <%= p('concourse_alerts.worker_containers.evaluation_time') %>
+  LABELS {
+    service = "concourse",
+    severity = "warning",
+  }
+  ANNOTATIONS {
+    summary = "Concourse worker `{{$bosh_deployment}}/{{$worker}}` is reporting too many containers",
+    description = "Concourse worker `{{$bosh_deployment}}/{{$worker}}` is reporting too many containers: {{$value}}",
+  }


### PR DESCRIPTION
* I don't personally plan to alert on goroutes, mallocs, etc., so I didn't include those. I'd be happy to add more alerts if others would find them useful.
* Metrics like `http-response-time` won't work with the influx exporter, since concourse sends a metric for each request, and the exporter doesn't seem to know how to aggregate them. I'm guessing concourse would need to emit aggregates for these metrics to be useful here. Or we could propose some form of configurable aggregate for the influx exporter, or even fork it to add concourse-specific behavior.
* At the moment, concourse metrics from the influx exporter aren't namespaced at all, which is why the metric referenced here is `worker_containers` and not something more explicit like `concourse_worker_containers`. I suggested https://github.com/prometheus/influxdb_exporter/issues/12, which would allow us to namespace concourse-related metrics.

cc @wjwoodson @LinuxBozo