### PR TITLE
Use release 17.6.1 in manifest

### DIFF
--- a/manifests/prometheus.yml
+++ b/manifests/prometheus.yml
@@ -124,9 +124,9 @@ variables:
 
 releases:
 - name: prometheus
-  version: 16.0.2
-  url: https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=16.0.2
-  sha1: 99dafd66dc604cc34c504c5b028331493c774270
+  version: 17.6.1
+  url: https://bosh.io/d/github.com/cloudfoundry-community/prometheus-boshrelease?v=17.6.1
+  sha1: a971f74ed1173f9965fae06637f9fd5e9ccb0b34
 update:
   canaries: 1
   max_in_flight: 32


### PR DESCRIPTION
These changes: https://github.com/cloudfoundry-community/prometheus-boshrelease/commit/5048a64cf1ab2a1f5b03b62befef603a6219ee78
Also require the latest version of the release.