### PR TITLE
Adding route prefix to the alertmanager url

### DIFF
--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -16,6 +16,7 @@ provides:
     properties:
       - alertmanager.mesh.port
       - alertmanager.web.port
+      - alertmanager.web.route_prefix
 
 consumes:
   - name: alertmanager

--- a/jobs/prometheus/templates/bin/prometheus_ctl
+++ b/jobs/prometheus/templates/bin/prometheus_ctl
@@ -30,7 +30,7 @@ case $1 in
       -alertmanager.timeout="<%= timeout %>" \
       <% end %> \
       <% if_link('alertmanager') do |alertmanager| %> \
-      -alertmanager.url="<%= alertmanager.instances.map { |instance| "http://#{instance.address}:#{alertmanager.p('alertmanager.web.port')}" }.join(',') %>" \
+      -alertmanager.url="<%= alertmanager.instances.map { |instance| "http://#{instance.address}:#{alertmanager.p('alertmanager.web.port')}#{alertmanager.p('alertmanager.web.route_prefix')}" }.join(',') %>" \
       <% end %> \
       <% if_p('prometheus.log_format') do |log_format| %> \
       -log.format="<%= log_format %>" \

--- a/jobs/prometheus/templates/bin/prometheus_ctl
+++ b/jobs/prometheus/templates/bin/prometheus_ctl
@@ -30,7 +30,7 @@ case $1 in
       -alertmanager.timeout="<%= timeout %>" \
       <% end %> \
       <% if_link('alertmanager') do |alertmanager| %> \
-      -alertmanager.url="<%= alertmanager.instances.map { |instance| "http://#{instance.address}:#{alertmanager.p('alertmanager.web.port')}#{alertmanager.p('alertmanager.web.route_prefix')}" }.join(',') %>" \
+      -alertmanager.url="<%= alertmanager.instances.map { |instance| URI.join("http://#{instance.address}:#{alertmanager.p('alertmanager.web.port')}","#{alertmanager.p('alertmanager.web.route_prefix',"")}") }.join(',') %>" \
       <% end %> \
       <% if_p('prometheus.log_format') do |log_format| %> \
       -log.format="<%= log_format %>" \


### PR DESCRIPTION
If you have to use a route prefix for the alertmanager, prometheus has to know about it.