### PR TITLE
Bump alerts for latest elasticsearch exporter.

### DIFF
--- a/jobs/elasticsearch_alerts/spec
+++ b/jobs/elasticsearch_alerts/spec
@@ -15,3 +15,9 @@ properties:
     default: 5m
   elasticsearch_alerts.cluster_yellow.evaluation_time:
     description: "Elasticsearch cluster health yellow evaluation time"
+  elasticsearch_alerts.heap_usage.threshold:
+    description: "Elasticsearch heap usage proportion threshold (0 to 1)"
+    default: 0.9
+  elasticsearch_alerts.heap_usage.evaluation_time:
+    description: "Elasticsearch heap usage evaluation time"
+    default: 5m

--- a/jobs/elasticsearch_alerts/templates/cluster.alerts
+++ b/jobs/elasticsearch_alerts/templates/cluster.alerts
@@ -1,5 +1,5 @@
 ALERT ElasticUp
-  IF elasticsearch_up != 1
+  IF elasticsearch_cluster_health_up != 1
   FOR <%= p('elasticsearch_alerts.cluster_down.evaluation_time') %>
   LABELS {
     service = "elasticsearch",
@@ -11,7 +11,7 @@ ALERT ElasticUp
   }
 
 ALERT ElasticClusterRed
-  IF elasticsearch_cluster_health_status == 2
+  IF elasticsearch_cluster_health_status{color="red"} == 1
   FOR <%= p('elasticsearch_alerts.cluster_red.evaluation_time') %>
   LABELS {
     service = "elasticsearch",
@@ -24,7 +24,7 @@ ALERT ElasticClusterRed
 
 <% if_p('elasticsearch_alerts.cluster_yellow.evaluation_time') do |time| %>
 ALERT ElasticClusterYellow
-  IF elasticsearch_cluster_health_status == 1
+  IF elasticsearch_cluster_health_status{color="yellow"} == 1
   FOR <%= time %>
   LABELS {
     service = "elasticsearch",
@@ -35,3 +35,15 @@ ALERT ElasticClusterYellow
     description = "Cluster {{$labels.cluster}} is yellow",
   }
 <% end %>
+
+ALERT ElasticHeapUsage
+  IF elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"} > <%= p('elasticsearch_alerts.heap_usage.threshold') %>
+  FOR <%= p('elasticsearch_alerts.heap_usage.evaluation_time') %>
+  LABELS {
+    service = "elasticsearch",
+    severity = "warning",
+  }
+  ANNOTATIONS {
+    summary = "Heap usage on node `{{$labels.cluster}}/{{$name}}` has been over <%= p('elasticsearch_alerts.heap_usage.threshold') %> for a long time",
+    description = "Heap usage on node `{{$labels.cluster}}/{{$name}}` has been over <%= p('elasticsearch_alerts.heap_usage.threshold') %> for <%= p('elasticsearch_alerts.heap_usage.evaluation_time') %>",
+  }

--- a/jobs/elasticsearch_dashboards/templates/elasticsearch.json
+++ b/jobs/elasticsearch_dashboards/templates/elasticsearch.json
@@ -230,91 +230,6 @@
       "panels": [
         {
           "cacheTimeout": null,
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(255, 166, 0, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_PROMETHEUS}",
-          "editable": true,
-          "error": false,
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "height": "50",
-          "id": 8,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 5,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "targets": [
-            {
-              "expr": "elasticsearch_cluster_health_status_is_green{instance=\"$instance\"}",
-              "intervalFactor": 2,
-              "legendFormat": "",
-              "metric": "",
-              "refId": "A",
-              "step": 1800
-            }
-          ],
-          "thresholds": "0,1",
-          "title": "Cluster health status",
-          "transparent": false,
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "GREEN",
-              "value": "1"
-            },
-            {
-              "op": "=",
-              "text": "RED",
-              "value": "0"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
           "colorBackground": false,
           "colorValue": false,
           "colors": [
@@ -362,7 +277,7 @@
               "to": "null"
             }
           ],
-          "span": 2,
+          "span": 4,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": false,
@@ -443,7 +358,7 @@
               "to": "null"
             }
           ],
-          "span": 2,
+          "span": 4,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": false,
@@ -525,7 +440,7 @@
               "to": "null"
             }
           ],
-          "span": 3,
+          "span": 4,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": false,
@@ -1017,7 +932,7 @@
               "expr": "elasticsearch_process_cpu_percent{instance=\"$instance\"}",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1191,7 +1106,7 @@
               "expr": "1-(elasticsearch_filesystem_data_available_bytes{instance=\"$instance\"}/elasticsearch_filesystem_data_size_bytes{instance=\"$instance\"})",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} - {{path}}",
+              "legendFormat": "{{name}} - {{path}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1301,7 +1216,7 @@
               "expr": "elasticsearch_indices_docs{instance=\"$instance\"}",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1384,7 +1299,7 @@
               "expr": "irate(elasticsearch_indices_indexing_index_total{instance=\"$instance\"}[$interval])",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1467,7 +1382,7 @@
               "expr": "rate(elasticsearch_indices_docs_deleted{instance=\"$instance\"}[$interval])",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1550,7 +1465,7 @@
               "expr": "rate(elasticsearch_indices_merges_total{instance=\"$instance\"}[$interval])",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1642,10 +1557,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(elasticsearch_indices_search_query_time_ms_total{instance=\"$instance\"}[$interval]) ",
+              "expr": "rate(elasticsearch_indices_search_query_time_seconds{instance=\"$instance\"}[$interval]) ",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1725,10 +1640,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(elasticsearch_indices_indexing_index_time_ms_total{instance=\"$instance\"}[$interval])",
+              "expr": "rate(elasticsearch_indices_indexing_index_time_seconds_total{instance=\"$instance\"}[$interval])",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1808,10 +1723,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(elasticsearch_indices_merges_total_time_ms_total{instance=\"$instance\"}[$interval])",
+              "expr": "rate(elasticsearch_indices_merges_total_time_seconds_total{instance=\"$instance\"}[$interval])",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1906,7 +1821,7 @@
               "expr": "elasticsearch_indices_fielddata_memory_size_bytes{instance=\"$instance\"}",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -1989,7 +1904,7 @@
               "expr": "rate(elasticsearch_indices_fielddata_evictions{instance=\"$instance\"}[$interval])",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -2072,7 +1987,7 @@
               "expr": "elasticsearch_indices_query_cache_memory_size_bytes{instance=\"$instance\"}",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -2155,7 +2070,7 @@
               "expr": "rate(elasticsearch_indices_query_cache_evictions{instance=\"$instance\"}[$interval])",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{name}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -2567,7 +2482,7 @@
               "expr": "rate(elasticsearch_jvm_gc_collection_seconds_count{instance=\"$instance\"}[$interval])",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} - {{gc}}",
+              "legendFormat": "{{name}} - {{gc}}",
               "metric": "",
               "refId": "A",
               "step": 240
@@ -2650,7 +2565,7 @@
               "expr": "rate(elasticsearch_jvm_gc_collection_seconds_count{instance=\"$instance\"}[$interval])",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}} - {{gc}}",
+              "legendFormat": "{{name}} - {{gc}}",
               "metric": "",
               "refId": "A",
               "step": 240


### PR DESCRIPTION
The elasticsearch exporter refactored and renamed alerts recently. This patch updates alerts for release https://github.com/justwatchcom/elasticsearch_exporter/releases/tag/v1.0.1. We'll also need to update the elasticsearch dashboard and package the new release. I'll take a look at the dashboard later this week; @frodenas, could you add the new release when you get a chance?