### PR TITLE
Allow grafana to use prometheus_ip even when external_url is provided

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -411,6 +411,9 @@ properties:
     default: DS_PROMETHEUS
   grafana.prometheus.dashboard_files:
     description: "Array of dashboard json file locations or glob patterns"
+  grafana.prometheus.use_external_url:
+    description: "If true and prometheus provides one, use the external url to reach prometheus"
+    default: true
 
   env.http_proxy:
     description: "HTTP proxy to use"

--- a/jobs/grafana/templates/bin/prometheus-datasource
+++ b/jobs/grafana/templates/bin/prometheus-datasource
@@ -17,14 +17,16 @@ GRAFANA_CREDENTIALS="<%= p('grafana.security.admin_user') %>:<%= p('grafana.secu
   pbasic_auth_password = ""
 
   # If prometheus is using an external url, use it instead of the prometheus instance private ip addresses
-  prometheus.if_p('prometheus.web.external_url') do |prometheus_external_url|
-    purl = prometheus_external_url
-    if_link('nginx') do |nginx|
-      # If prometheus is secured by basic auth, set the credentials
-      nginx.if_p('nginx.prometheus.auth_username', 'nginx.prometheus.auth_password') do |prometheus_auth_username, prometheus_auth_password|
-        pbasic_auth = "true"
-        pbasic_auth_user = prometheus_auth_username
-        pbasic_auth_password = prometheus_auth_password
+  if p('grafana.prometheus.use_external_url') then
+    prometheus.if_p('prometheus.web.external_url') do |prometheus_external_url|
+      purl = prometheus_external_url
+      if_link('nginx') do |nginx|
+        # If prometheus is secured by basic auth, set the credentials
+        nginx.if_p('nginx.prometheus.auth_username', 'nginx.prometheus.auth_password') do |prometheus_auth_username, prometheus_auth_password|
+          pbasic_auth = "true"
+          pbasic_auth_user = prometheus_auth_username
+          pbasic_auth_password = prometheus_auth_password
+        end
       end
     end
   end


### PR DESCRIPTION
In some network configurations it's advantageous to have grafana communicate directly with prometheus even when prometheus has been configured with `web.external_url`.

This PR adds a flag to allow this which defaults to preserving the existing behaivor of using the external url when one is provided.

cc: @jmcarp 