### PR TITLE
mysqld_exporter for mysql job instead of mongo_exporter

### DIFF
--- a/manifests/operators/monitor-bosh.yml
+++ b/manifests/operators/monitor-bosh.yml
@@ -326,7 +326,7 @@
     relabel_configs:
       - source_labels:
         - __meta_bosh_job_process_name
-        regex: mongodb_exporter
+        regex: mysqld_exporter
         action: keep
       - source_labels:
         - __address__


### PR DESCRIPTION
mysql job auto discovery regex contained mondogdb_exported instead of mysqld_exporter.