### PR TITLE
Automatically create influxdb datasource

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -14,6 +14,7 @@ templates:
   bin/pre-start: bin/pre-start
   bin/prometheus-dashboards: bin/prometheus-dashboards
   bin/prometheus-datasource: bin/prometheus-datasource
+  bin/influxdb-datasource: bin/influxdb-datasource
   config/database_tls_client_ca.pem: config/database_tls_client_ca.pem
   config/database_tls_client_cert.pem: config/database_tls_client_cert.pem
   config/database_tls_client_key.pem: config/database_tls_client_key.pem
@@ -444,7 +445,19 @@ properties:
   grafana.influxdb.datasource_input_name:
     description: "Name of the InfluxDB datasource input name"
     default: DS_INFLUXDB
-
+  grafana.influxdb.url:
+    description: "InfluxDB URL to configure as Grafana data source"
+    default: ""
+  grafana.influxdb.database:
+    description: "InfluxDB database to configure as Grafana data source"
+    default: ""
+  grafana.influxdb.username:
+    description: "InfluxDB user to configure as Grafana data source"
+    default: ""
+  grafana.influxdb.password:
+    description: "InfluxDB password to configure as Grafana data source"
+    default: ""
+  
   env.http_proxy:
     description: "HTTP proxy to use"
   env.https_proxy:

--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -447,16 +447,12 @@ properties:
     default: DS_INFLUXDB
   grafana.influxdb.url:
     description: "InfluxDB URL to configure as Grafana data source"
-    default: ""
   grafana.influxdb.database:
     description: "InfluxDB database to configure as Grafana data source"
-    default: ""
   grafana.influxdb.username:
     description: "InfluxDB user to configure as Grafana data source"
-    default: ""
   grafana.influxdb.password:
     description: "InfluxDB password to configure as Grafana data source"
-    default: ""
   
   env.http_proxy:
     description: "HTTP proxy to use"

--- a/jobs/grafana/templates/bin/influxdb-datasource
+++ b/jobs/grafana/templates/bin/influxdb-datasource
@@ -2,41 +2,35 @@
 
 set -eu
 
-GRAFANA_DATASOURCES_API="<%= p('grafana.server.protocol', 'http') %>://<%= spec.ip %>:<%= p('grafana.server.http_port') %>/api/datasources"
-GRAFANA_CREDENTIALS="<%= p('grafana.security.admin_user') %>:<%= p('grafana.security.admin_password') %>"
-DATASOURCE_ID=""
+<% if_p('grafana.influxdb.url') do |influxdb_url| %>
+  GRAFANA_DATASOURCES_API="<%= p('grafana.server.protocol', 'http') %>://<%= spec.ip %>:<%= p('grafana.server.http_port') %>/api/datasources"
+  GRAFANA_CREDENTIALS="<%= p('grafana.security.admin_user') %>:<%= p('grafana.security.admin_password') %>"
 
-<% if p('grafana.influxdb.url') %>
-  INFLUXDB_URL="<%= p('grafana.influxdb.url') %>"
+  INFLUXDB_URL="<%= grafana.influxdb.url %>"
   INFLUXDB_DATABASE="<%= p('grafana.influxdb.database') %>"
   INFLUXDB_USERNAME="<%= p('grafana.influxdb.username') %>"
   INFLUXDB_PASSWORD="<%= p('grafana.influxdb.password') %>"
+
+  DATASOURCE_NAME="<%= p('grafana.influxdb.datasource_name') %>"
+  DATASOURCE_DATA="{\"name\":\"${DATASOURCE_NAME}\",\"type\":\"influxdb\",\"access\":\"proxy\",\"url\":\"${INFLUXDB_URL}\",\"password\":\"${INFLUXDB_PASSWORD}\",\"user\":\"${INFLUXDB_USERNAME}\",\"database\":\"${INFLUXDB_DATABASE}\",\"isDefault\":false,\"jsonData\":null}"
+    
+  DATASOURCE_ID=$(curl -u ${GRAFANA_CREDENTIALS} -ks ${GRAFANA_DATASOURCES_API} | sed -n 's/^.*"id":\([0-9]*\)[^}]*"name":"'${DATASOURCE_NAME}'".*$/\1/p' )
+
+  if [ -n "${DATASOURCE_ID}" ]; then
+    if curl -u ${GRAFANA_CREDENTIALS} -ksf -X PUT ${GRAFANA_DATASOURCES_API}/${DATASOURCE_ID} -H 'Content-Type: application/json' -d "${DATASOURCE_DATA}" ; then
+      echo -e "\nUpdated datasource ${DATASOURCE_NAME} at $(date)"
+    else
+      echo -e "\nFailed to update datasource ${DATASOURCE_NAME} at $(date)"
+      exit 1
+    fi
+  else
+    if curl -u ${GRAFANA_CREDENTIALS} -ksf -X POST ${GRAFANA_DATASOURCES_API} -H 'Content-Type: application/json' -d "${DATASOURCE_DATA}" ; then
+      echo -e "\nCreated datasource ${DATASOURCE_NAME} at $(date)"
+    else
+      echo -e "\nFailed to create datasource ${DATASOURCE_NAME} at $(date)"
+      exit 1
+    fi
+  fi
 <% end %>
-
-if [ ! -n "${INFLUXDB_URL}" ]; then
-  echo -e "\nNo InfluxDB datasource to configure"
-  exit 0
-fi
-
-DATASOURCE_NAME="<%= p('grafana.influxdb.datasource_name') %>"
-DATASOURCE_DATA="{\"name\":\"${DATASOURCE_NAME}\",\"type\":\"influxdb\",\"access\":\"proxy\",\"url\":\"${INFLUXDB_URL}\",\"password\":\"${INFLUXDB_PASSWORD}\",\"user\":\"${INFLUXDB_USERNAME}\",\"database\":\"${INFLUXDB_DATABASE}\",\"isDefault\":false,\"jsonData\":null}"
-  
-DATASOURCE_ID=$(curl -u ${GRAFANA_CREDENTIALS} -ks ${GRAFANA_DATASOURCES_API} | sed -n 's/^.*"id":\([0-9]*\)[^}]*"name":"'${DATASOURCE_NAME}'".*$/\1/p' )
-
-if [ -n "${DATASOURCE_ID}" ]; then
-  if curl -u ${GRAFANA_CREDENTIALS} -ksf -X PUT ${GRAFANA_DATASOURCES_API}/${DATASOURCE_ID} -H 'Content-Type: application/json' -d "${DATASOURCE_DATA}" ; then
-    echo -e "\nUpdated datasource ${DATASOURCE_NAME} at $(date)"
-  else
-    echo -e "\nFailed to update datasource ${DATASOURCE_NAME} at $(date)"
-    exit 1
-  fi
-else
-  if curl -u ${GRAFANA_CREDENTIALS} -ksf -X POST ${GRAFANA_DATASOURCES_API} -H 'Content-Type: application/json' -d "${DATASOURCE_DATA}" ; then
-    echo -e "\nCreated datasource ${DATASOURCE_NAME} at $(date)"
-  else
-    echo -e "\nFailed to create datasource ${DATASOURCE_NAME} at $(date)"
-    exit 1
-  fi
-fi
 
 exit 0

--- a/jobs/grafana/templates/bin/influxdb-datasource
+++ b/jobs/grafana/templates/bin/influxdb-datasource
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eu
+
+GRAFANA_DATASOURCES_API="<%= p('grafana.server.protocol', 'http') %>://<%= spec.ip %>:<%= p('grafana.server.http_port') %>/api/datasources"
+GRAFANA_CREDENTIALS="<%= p('grafana.security.admin_user') %>:<%= p('grafana.security.admin_password') %>"
+DATASOURCE_ID=""
+
+<% if p('grafana.influxdb.url') %>
+  INFLUXDB_URL="<%= p('grafana.influxdb.url') %>"
+  INFLUXDB_DATABASE="<%= p('grafana.influxdb.database') %>"
+  INFLUXDB_USERNAME="<%= p('grafana.influxdb.username') %>"
+  INFLUXDB_PASSWORD="<%= p('grafana.influxdb.password') %>"
+<% end %>
+
+if [ ! -n "${INFLUXDB_URL}" ]; then
+  echo -e "\nNo InfluxDB datasource to configure"
+  exit 0
+fi
+
+DATASOURCE_NAME="<%= p('grafana.influxdb.datasource_name') %>"
+DATASOURCE_DATA="{\"name\":\"${DATASOURCE_NAME}\",\"type\":\"influxdb\",\"access\":\"proxy\",\"url\":\"${INFLUXDB_URL}\",\"password\":\"${INFLUXDB_PASSWORD}\",\"user\":\"${INFLUXDB_USERNAME}\",\"database\":\"${INFLUXDB_DATABASE}\",\"isDefault\":false,\"jsonData\":null}"
+  
+DATASOURCE_ID=$(curl -u ${GRAFANA_CREDENTIALS} -ks ${GRAFANA_DATASOURCES_API} | sed -n 's/^.*"id":\([0-9]*\)[^}]*"name":"'${DATASOURCE_NAME}'".*$/\1/p' )
+
+if [ -n "${DATASOURCE_ID}" ]; then
+  if curl -u ${GRAFANA_CREDENTIALS} -ksf -X PUT ${GRAFANA_DATASOURCES_API}/${DATASOURCE_ID} -H 'Content-Type: application/json' -d "${DATASOURCE_DATA}" ; then
+    echo -e "\nUpdated datasource ${DATASOURCE_NAME} at $(date)"
+  else
+    echo -e "\nFailed to update datasource ${DATASOURCE_NAME} at $(date)"
+    exit 1
+  fi
+else
+  if curl -u ${GRAFANA_CREDENTIALS} -ksf -X POST ${GRAFANA_DATASOURCES_API} -H 'Content-Type: application/json' -d "${DATASOURCE_DATA}" ; then
+    echo -e "\nCreated datasource ${DATASOURCE_NAME} at $(date)"
+  else
+    echo -e "\nFailed to create datasource ${DATASOURCE_NAME} at $(date)"
+    exit 1
+  fi
+fi
+
+exit 0

--- a/jobs/grafana/templates/bin/post-start
+++ b/jobs/grafana/templates/bin/post-start
@@ -30,6 +30,9 @@ $(dirname $0)/grafana-users
 echo "[$(date)] Calling 'prometheus-datasource' ..."
 $(dirname $0)/prometheus-datasource
 
+echo "[$(date)] Calling 'influxdb-datasource' ..."
+$(dirname $0)/influxdb-datasource
+
 echo "[$(date)] Calling 'prometheus-dashboards' ..."
 $(dirname $0)/prometheus-dashboards
 


### PR DESCRIPTION
Related to: https://github.com/cloudfoundry-community/prometheus-boshrelease/pull/118
This PR adds automatic creation of influxdb datasource in Grafana if grafana.influxdb.* properties are set. It currently doesn't support BOSH links  - this can be added in the future but currently no InfluxDB bosh releases provide links anyway.