### PR TITLE
Fix Elasticsearch dashboard templating

### DIFF
--- a/jobs/elasticsearch_dashboards/templates/elasticsearch.json
+++ b/jobs/elasticsearch_dashboards/templates/elasticsearch.json
@@ -160,7 +160,7 @@
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(elasticsearch_up,instance)",
+        "query": "label_values(elasticsearch_cluster_health_up,instance)",
         "refresh": 1,
         "regex": "",
         "sort": 1,


### PR DESCRIPTION
Elasticsearch dashboard templating is not working because since justwatchcom/elasticsearch_exporter#65 the elasticsearch_up metric is in the elasticsearch_cluster_health namespace.

This fixes commit e2925b2.