### PR TITLE
Honor scraped labels when scraping push gateway.

### DIFF
--- a/manifests/operators/monitor-bosh.yml
+++ b/manifests/operators/monitor-bosh.yml
@@ -410,6 +410,7 @@
   path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: pushgateway
+    honor_labels: true
     file_sd_configs:
       - files:
         - "/var/vcap/store/bosh_exporter/bosh_target_groups.json"


### PR DESCRIPTION
As recommended by
https://github.com/prometheus/pushgateway#about-the-job-and-instance-labels.