### PR TITLE
Ignore smoke-test VMs when predicting ephemeral disk will fill

### DIFF
--- a/jobs/bosh_alerts/templates/bosh_system_predict.alerts
+++ b/jobs/bosh_alerts/templates/bosh_system_predict.alerts
@@ -11,7 +11,7 @@ ALERT BOSHJobSystemDiskPredictWillFill
   }
 
   ALERT BOSHJobEphemeralDiskPredictWillFill
-  IF predict_linear(bosh_job_ephemeral_disk_percent{bosh_job_name!~"^compilation.*"}[1h], <%= p('bosh_alerts.job_predict_ephemeral_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_ephemeral_disk_full.threshold') %>
+  IF predict_linear(bosh_job_ephemeral_disk_percent{bosh_job_name!~"^(compilation|smoke-tests).*"}[1h], <%= p('bosh_alerts.job_predict_ephemeral_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_ephemeral_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_predict_ephemeral_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",

--- a/jobs/bosh_alerts/templates/bosh_tsdb_system_predict.alerts
+++ b/jobs/bosh_alerts/templates/bosh_tsdb_system_predict.alerts
@@ -11,7 +11,7 @@ ALERT BOSHTSDBJobSystemDiskPredictWillFill
   }
 
 ALERT BOSHTSDBJobEphemeralDiskPredictWillFill
-  IF predict_linear(bosh_tsdb_job_ephemeral_disk_percent{bosh_job_name!~"^compilation.*"}[1h], <%= p('bosh_alerts.job_predict_ephemeral_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_ephemeral_disk_full.threshold') %>
+  IF predict_linear(bosh_tsdb_job_ephemeral_disk_percent{bosh_job_name!~"^(compilation|smoke-tests).*"}[1h], <%= p('bosh_alerts.job_predict_ephemeral_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_ephemeral_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_predict_ephemeral_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",


### PR DESCRIPTION
When using Pivotal Cloud Foundry we get false alarms due to BOSHJobEphemeralDiskPredictWillFill alerts on short-lived errand VMs running CF smoke tests.

We've tested this by creating the alerts manually in the prometheus UI and asserting that the alerts are not triggered